### PR TITLE
createアクションの作成

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -39,4 +39,10 @@ class ApplicationController < ActionController::API
   def authorized
     render json: { message: 'Please log in' }, status: :unauthorized unless logged_in?
   end
+
+  #postする時のuser idをtokenから取得する
+  def user_authentication
+    @user_id = decoded_token[0]['user_id']['user_id']
+  end
+  
 end

--- a/app/controllers/attendances_controller.rb
+++ b/app/controllers/attendances_controller.rb
@@ -1,6 +1,28 @@
 class AttendancesController < ApplicationController
     def index
-        @example_json = {'hello' => 'world'}
-        render json: @example_json
+        #自分のレコードだけ表示する
+        example_json = {'hello' => 'world'}
+        render json: example_json
     end
+    #打刻アクション
+    def create
+        @attendance = Attendance.new(attendance_params)
+
+        # response
+        if @attendance.save
+            render json: @attendance, status: :created, location: attendances_url
+        else
+            render json: @attendance.errors, status: :unprocessable_entity
+        end
+    end
+
+    private
+    def attendance_params
+        #ユーザーidもこちらに移動する
+        attendance_params = params.require(:attendance).permit(:date, :start_time, :end_time)
+        user_id = user_authentication
+        attendance_params["user_id"] = user_id
+        return attendance_params
+    end
+
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,4 @@
 class User < ApplicationRecord
     has_secure_password
+    has_many :attendances
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   resources :drivers
   resource :users, only: [:create]
   #resource :attendances, only: [:index]
-  resources :attendances, only: [:index]
+  resources :attendances, only: [:index, :create]
   post "/login", to: "users#login"
   get "/auto_login", to: "users#auto_login"
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html


### PR DESCRIPTION
attendance_params関数で
Applicationコントローラーでユーザー認証用のコールバック関数を呼び出し実行しuser_idを取得し、postしたハッシュにuser_i
d keyを追加し、DBにpost格納するレコードを作成した
Createアクション内でDBにpost実行、saveできたらjsonを返す処理を実行する